### PR TITLE
fix: don't fail when 'src' and 'href' are undefined

### DIFF
--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -460,5 +460,26 @@ configs.forEach(c => {
                 done();
             });
         });
+
+        it('should not fail on meta links - plugin.skipAssets.regex', (done) => {
+            webpack({ ...c.options,
+                plugins: [
+                    ...c.options.plugins,
+                    new HtmlWebpackPlugin({
+                        ...HtmlWebpackPluginOptions,
+                        meta: {
+                            robots: `none`,
+                        },
+                    }),
+                    new HtmlWebpackSkipAssetsPlugin({
+                        skipAssets: [/styles.js/]
+                    }),
+                ]
+            }, (err, stats) => {
+                expect(!!err).to.be.false;
+                expect(stats.hasErrors()).to.be.false;
+                done();
+            });
+        });
     });
 });

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -96,17 +96,23 @@ export class HtmlWebpackSkipAssetsPlugin {
                 if (!matcher) {
                     return false;
                 }
+                
+                if (typeof matcher === 'function') {
+                    const matchesCallback = matcher(a);
+                    return !!(matchesCallback);
+                }
+
                 const assetUrl: string = (a.attributes.src || a.attributes.href) as string;
+                if (assetUrl === undefined) {
+                    return false
+                }
+
                 if (typeof matcher === 'string') {
                     return minimatch(assetUrl, matcher);
                 }
                 if (matcher.constructor && matcher.constructor.name === 'RegExp') {
                     const regexMatcher = (matcher as RegExp);
                     return !!(assetUrl.match(regexMatcher));
-                }
-                if (typeof matcher === 'function') {
-                    const matchesCallback = matcher(a);
-                    return !!(matchesCallback);
                 }
                 return false;
             });

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -96,23 +96,17 @@ export class HtmlWebpackSkipAssetsPlugin {
                 if (!matcher) {
                     return false;
                 }
-                
-                if (typeof matcher === 'function') {
-                    const matchesCallback = matcher(a);
-                    return !!(matchesCallback);
-                }
-
-                const assetUrl: string = (a.attributes.src || a.attributes.href) as string;
-                if (assetUrl === undefined) {
-                    return false
-                }
-
+                const assetUrl: string = (a.attributes.src ?? a.attributes.href ?? '') as string;
                 if (typeof matcher === 'string') {
                     return minimatch(assetUrl, matcher);
                 }
                 if (matcher.constructor && matcher.constructor.name === 'RegExp') {
                     const regexMatcher = (matcher as RegExp);
                     return !!(assetUrl.match(regexMatcher));
+                }
+                if (typeof matcher === 'function') {
+                    const matchesCallback = matcher(a);
+                    return !!(matchesCallback);
                 }
                 return false;
             });


### PR DESCRIPTION
Hi 👋 

Thank you for this great plugin 🚀 

While working on https://github.com/gatsbyjs/gatsby/issues/31909 I hit a bug where `src` and `href` can be `undefined` causing the plugin to crash.

I can workaround by supplying a function, but thought it will be good to fix this in the plugin.

Added a test case that reproduces the bug.