### PR TITLE
Patch minimatch to fix CVE-2022-3517

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "webpack": ">=3.0.0"
   },
   "dependencies": {
-    "minimatch": ">=3.0.5"
+    "minimatch": "3.0.5"
   },
   "peerDependencies": {
     "html-webpack-plugin": ">=3.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "webpack": ">=3.0.0"
   },
   "dependencies": {
-    "minimatch": "3.0.4"
+    "minimatch": ">=3.0.5"
   },
   "peerDependencies": {
     "html-webpack-plugin": ">=3.0.0",


### PR DESCRIPTION
Upgrade minimatch to the earliest version where CVE-2022-3517, a high severity issue (7.5/10) was fixed. https://nvd.nist.gov/vuln/detail/CVE-2022-3517